### PR TITLE
add framework.js as a proxy in split-mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,9 @@ var initExtJs = function (config, helper) {
 
   if (microloader.split) {
     files.push(createPattern('framework.js', false, basePath, helper));
+    applyIf(proxies, {
+      '/framework.js': '/base/framework.js',
+    });
   }
 
   files.push(


### PR DESCRIPTION
If we are in split-mode, we not only want framework.js to be in files but also added as a proxy.